### PR TITLE
add StreamInfo message for gossip/keep-alive reasons [SDC-1559]

### DIFF
--- a/hooks/domain/v1/domain.proto
+++ b/hooks/domain/v1/domain.proto
@@ -28,6 +28,12 @@ message LogRecord {
     }
 }
 
+// Context specific information about the current stream.
+// Also used for keep alives and other gossip.
+message StreamInfo {
+    google.protobuf.Timestamp timestamp = 2;
+}
+
 // WARNING ! DIFFERENT FROM  logitics/v1alpha/hook.proto
 message StateChangeAction {
     enum Type {

--- a/hooks/service/v1/hooks.proto
+++ b/hooks/service/v1/hooks.proto
@@ -38,13 +38,16 @@ message SubscribeChangeRequest {
 
 // ---------------------
 // Subscribe Response
-// The response guarantees that all entities in the response are ordered in a consistent way.
+// The log record response guarantees that all entities in the response are ordered in a consistent way.
 // By consistent it means:
 // 1) by creation timestamp (for initial state loading), by modified timestamp/when things happening (after initial loading, stream) - whereas a "timestamp"
 //    should be strictly ordered (sequence, ...) OR
 // 2) by acyclic dependencies (for initial state loading), same as 1) after initial loading.
 // ---------------------
 message SubscribeChangeResponse {
-    io.spoud.sdm.hooks.domain.v1.LogRecord log_record = 1;
+    oneof response {
+      io.spoud.sdm.hooks.domain.v1.LogRecord log_record = 1;
+      io.spoud.sdm.hooks.domain.v1.StreamInfo stream_info = 2;
+    }
 }
 


### PR DESCRIPTION
SDC-1559

As discussed w/ @spike83 and @sambenz . Let's use an explicit keep-alive through a context aware info which is sent out periodically (e.g. every 30s). With that approach we can be sure, that no proxy in between is doing some magic or also ignore pings (heard of such things as well).
On the client side it's important to only process a LogRecord when it's there (check for `hasLogRecord()` or similar). The StreamInfo will hold more infos in the future - but is sufficient for now.