### PR TITLE
feat: add Maven and npm package builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /ts
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Lint proto files
+        run: buf lint
+
+      - name: Check for breaking changes
+        run: buf breaking --against '.git#branch=main'
+
+  build-java:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build Java package
+        run: mvn -B package
+
+  build-ts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Install dependencies
+        working-directory: ts
+        run: npm ci
+
+      - name: Build TypeScript package
+        working-directory: ts
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: bufbuild/buf-action@v1
         with:
@@ -24,7 +26,12 @@ jobs:
         run: buf lint
 
       - name: Check for breaking changes
-        run: buf breaking --against '.git#branch=main'
+        run: |
+          if git ls-tree origin/main --name-only | grep -q '^buf.yaml$'; then
+            buf breaking --against '.git#branch=main'
+          else
+            echo "Skipping: buf.yaml not found on main branch yet"
+          fi
 
   build-java:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  secrets-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets with Gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz | tar xz gitleaks
+          ./gitleaks detect --source . --no-git --verbose --redact --exit-code 1
+
+  release:
+    needs: secrets-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: https://npm.pkg.github.com
+
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build Java package
+        run: mvn -B clean package
+
+      - name: Build TypeScript package
+        working-directory: ts
+        run: npm ci && npm run build
+
+      - name: Bump version and push tag
+        id: tag
+        uses: anothrNick/github-tag-action@1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+
+      - uses: frabert/replace-string-action@v2.5
+        id: version
+        with:
+          pattern: 'v(.+)'
+          string: ${{ steps.tag.outputs.new_tag }}
+          replace-with: '$1'
+
+      - name: Publish Maven package
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.version.outputs.replaced }}
+          mvn -B deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish npm package
+        working-directory: ts
+        run: |
+          npm version ${{ steps.version.outputs.replaced }} --no-git-tag-version
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@
 out/
 .DS_Store
 
+# Maven
+target/
+*.class
+
+# Node
+ts/node_modules/
+ts/dist/
+ts/src/gen/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,67 @@
 # SDM Proto API
 
-This repository is the master of all proto files.
+Single source of truth for all SDM gRPC service definitions.
 
-All services can include it as submodule or just copy paste.
+Published as versioned packages for Java (Maven) and TypeScript (npm), so consumers can depend on specific versions and get automated updates via Dependabot.
 
-## Init the submodule in a service repository
+## Packages
 
-Be sure to remove any old proto folder before doing this (you will also need to commit).
+### Maven (Java + gRPC + Mutiny stubs)
 
-In this example we checkout in the folder `src/main/proto`.
-
-```shell script
-git submodule add git@github.com:spoud/sdm-proto-api.git src/main/proto
+```xml
+<dependency>
+  <groupId>io.spoud.sdm</groupId>
+  <artifactId>sdm-proto-api</artifactId>
+  <version>1.0.0</version>
+</dependency>
 ```
 
-## Update the submodule
-
-```shell script
-git submodule update --force --init --recursive --remote
+Requires the GitHub Packages Maven repository:
+```xml
+<repository>
+  <id>github</id>
+  <url>https://maven.pkg.github.com/spoud/sdm-proto-api</url>
+</repository>
 ```
+
+### npm (Connect-RPC TypeScript types)
+
+```bash
+npm install @spoud/sdm-proto-api
+```
+
+Requires `.npmrc` with GitHub Packages registry:
+```
+@spoud:registry=https://npm.pkg.github.com
+```
+
+## Development
+
+### Prerequisites
+
+- Java 21
+- Node.js 22
+- [Buf CLI](https://buf.build/docs/installation)
+
+### Building locally
+
+```bash
+# Lint proto files
+buf lint
+
+# Build Java package
+mvn -B package
+
+# Build TypeScript package
+cd ts && npm ci && npm run build
+```
+
+### Proto structure
+
+```
+activities/    blob/          collaboration/  global/
+hooks/         logistics/     looker/         permission/
+profiler/      schema/        search/         topology/
+```
+
+Each domain module contains `domain/`, `service/`, `selection/`, and/or `mutation/` subdirectories with versioned proto files (v1, v1alpha, v1alpha1).

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,5 @@
+version: v2
+plugins:
+  - local: protoc-gen-es
+    out: ts/src/gen
+    opt: target=ts

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,17 @@
+version: v2
+modules:
+  - path: .
+    excludes:
+      - target
+      - out
+      - ts
+lint:
+  use:
+    - MINIMAL
+  except:
+    # Package names use io.spoud.sdm.* prefix but directories omit that prefix
+    - PACKAGE_DIRECTORY_MATCH
+    - PACKAGE_SAME_DIRECTORY
+breaking:
+  use:
+    - FILE

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.spoud.sdm</groupId>
+  <artifactId>sdm-proto-api</artifactId>
+  <version>999-SNAPSHOT</version>
+
+  <name>sdm-proto-api</name>
+  <description>SDM Proto API - gRPC service definitions and generated Java stubs</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+
+    <protobuf.version>4.33.2</protobuf.version>
+    <grpc.version>1.82.0</grpc.version>
+    <quarkus.version>3.35.2</quarkus.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <version>${grpc.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-grpc</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.ascopes</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>5.1.4</version>
+        <configuration>
+          <protoc>${protobuf.version}</protoc>
+          <sourceDirectories>
+            <sourceDirectory>${project.basedir}</sourceDirectory>
+          </sourceDirectories>
+          <plugins>
+            <plugin kind="binary-maven">
+              <groupId>io.grpc</groupId>
+              <artifactId>protoc-gen-grpc-java</artifactId>
+              <version>${grpc.version}</version>
+            </plugin>
+            <plugin kind="jvm-maven">
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-grpc-protoc-plugin</artifactId>
+              <version>${quarkus.version}</version>
+              <mainClass>io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator</mainClass>
+            </plugin>
+          </plugins>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.5.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.15.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.21.0</version>
+        <configuration>
+          <generateBackupPoms>false</generateBackupPoms>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>github-releases</name>
+      <url>https://maven.pkg.github.com/spoud/sdm-proto-api</url>
+    </repository>
+  </distributionManagement>
+</project>

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,0 +1,287 @@
+{
+  "name": "@spoud/sdm-proto-api",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@spoud/sdm-proto-api",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@bufbuild/buf": "^1.50.0",
+        "@bufbuild/protobuf": "^2.6.0",
+        "@bufbuild/protoc-gen-es": "^2.6.0",
+        "@connectrpc/connect": "^2.0.0",
+        "typescript": "^5.7.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "@connectrpc/connect": "^2.0.0"
+      }
+    },
+    "node_modules/@bufbuild/buf": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.71.0.tgz",
+      "integrity": "sha512-GDcjBCwLgHT/4nX4YSnYatZ7sDZDpHV6dxQvoT2/P6gKvV23O6hl8NryzLIRKmeau0FRXpQKHVy1dMfnBSpy+w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "buf": "bin/buf",
+        "protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
+        "protoc-gen-buf-lint": "bin/protoc-gen-buf-lint"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@bufbuild/buf-darwin-arm64": "1.71.0",
+        "@bufbuild/buf-darwin-x64": "1.71.0",
+        "@bufbuild/buf-linux-aarch64": "1.71.0",
+        "@bufbuild/buf-linux-armv7": "1.71.0",
+        "@bufbuild/buf-linux-x64": "1.71.0",
+        "@bufbuild/buf-win32-arm64": "1.71.0",
+        "@bufbuild/buf-win32-x64": "1.71.0"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-arm64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.71.0.tgz",
+      "integrity": "sha512-qZ7xZQyen/jOKFPVs3dlN9pMA56PI4YEo3r4/9ixtiH9gyFgfowR31axsocUgXGThjiN8mvOA8WfpG2tvaSvsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-x64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.71.0.tgz",
+      "integrity": "sha512-2w95pc3X+z06/J66i6uNzA8QPuVOpbPrwyb6tkK0AcJFNvKPVYr4BxVC2koyImrQ3rxY1n9q8qviWMjSvq9fOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-aarch64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.71.0.tgz",
+      "integrity": "sha512-dwxErryMI3MRwtP/IgfdrqEjiAmVpttGhmO3xihiJIV2EAXt9J5yjzHhEDvnSgQ6nmNjEvO5QczcIaQjZEwF6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-armv7": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-armv7/-/buf-linux-armv7-1.71.0.tgz",
+      "integrity": "sha512-pfc+Qexm5C59VeRUjVmEvxkCXT5QbMR1R/CUtcSlk+spOFVwna0bSpkqIsky3kkHfzxiNSOsz3iki9/pAVX+CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-x64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.71.0.tgz",
+      "integrity": "sha512-Y7jLxr3wpMkpQSqZU/MrDmDSCkF4GxvhIL7wnNdSRpkhYAY6TPRHN+5nNgV7jp6mQ0zQSYh0MGxBeMgt/UVdmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-arm64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.71.0.tgz",
+      "integrity": "sha512-UrxtD99zLE1qImtQC/W3a9cuj0/kB53B1bK38kmCMRFow939FhdZtqTRjbnZWauRi/pzAsjDyPCvnTa2XKT8Cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-x64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.71.0.tgz",
+      "integrity": "sha512-+npiOimJ7ggeLul3KFwSlOjZnAZYwt3el64dJ3nJQMnui0avyvsRmU02o1bZI5yUnBvhcnTWdEbfRXUnkkVtgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@bufbuild/protoc-gen-es": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-2.12.1.tgz",
+      "integrity": "sha512-SWa7XvRYRouMo+vBQmpNFZ+ZEqQ8AC0LpL4QWAo1gvstLhFh/Y7Nf/a+MK7ZxDq5LZSThwfk974L1sFxO3OaGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.1",
+        "@bufbuild/protoplugin": "2.12.1"
+      },
+      "bin": {
+        "protoc-gen-es": "bin/protoc-gen-es"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "2.12.1"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-2.12.1.tgz",
+      "integrity": "sha512-PY58KxQVAD1BnnKtStOctsMoegEVGfBnY5AOqVQOIu711nA13oYtTqJM8df5lUQg2J1DR3XxUXptE+fWX5oLdA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.1",
+        "@typescript/vfs": "^1.6.2",
+        "typescript": "5.4.5"
+      }
+    },
+    "node_modules/@bufbuild/protoplugin/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+      "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@spoud/sdm-proto-api",
+  "version": "0.0.0",
+  "description": "SDM Proto API - Protobuf-ES TypeScript types and Connect-RPC service descriptors",
+  "type": "module",
+  "exports": {
+    "./*": "./dist/*"
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "generate": "cd .. && buf generate",
+    "build": "npm run generate && tsc",
+    "clean": "rm -rf dist/ src/gen/"
+  },
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^2.0.0",
+    "@connectrpc/connect": "^2.0.0"
+  },
+  "devDependencies": {
+    "@bufbuild/buf": "^1.50.0",
+    "@bufbuild/protobuf": "^2.6.0",
+    "@bufbuild/protoc-gen-es": "^2.6.0",
+    "@connectrpc/connect": "^2.0.0",
+    "typescript": "^5.7.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src/gen",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/gen/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add build infrastructure to publish `sdm-proto-api` as versioned Maven and npm packages, replacing git submodule consumption with standard dependency management
- Consumers will be able to depend on versioned packages and get automated updates via Dependabot
- No changes to proto files themselves

## Maven package (`io.spoud.sdm:sdm-proto-api`)

- Protobuf Java classes + gRPC blocking/async stubs + Quarkus Mutiny reactive stubs
- Jandex index for Quarkus ARC discovery
- Embedded `.proto` files in JAR
- Published to GitHub Packages Maven via `release.yml`

## npm package (`@spoud/sdm-proto-api`)

- Protobuf-ES v2 TypeScript types (compatible with Connect-RPC v2)
- Deep subpath imports: `import { ... } from "@spoud/sdm-proto-api/logistics/service/v1/data_offer_pb.js"`
- Published to GitHub Packages npm via `release.yml`

## Tooling

- **Buf CLI**: proto linting (`buf lint`) and backward compatibility checks (`buf breaking`) in CI
- **protobuf-maven-plugin** (ascopes v5.1.4): Java code generation with gRPC + Mutiny plugins
- **protoc-gen-es**: TypeScript generation via `buf generate`
- **GitHub Actions**: `build.yml` (PR validation) + `release.yml` (auto-tag + publish on merge)
- **Dependabot**: configured for maven, npm, and github-actions ecosystems

## Verified locally

- `mvn -B package` → 833 Java source files compiled, 2048 classes in JAR
- `buf lint` → passes clean
- `npm run build` (in `ts/`) → 51 TypeScript files compiled with declarations + source maps

## Test plan

- [ ] CI `build.yml` workflow passes on this PR (lint, breaking, mvn package, npm build)
- [ ] After merge, `release.yml` publishes v0.1.0 to GitHub Packages (Maven + npm)
- [ ] Consumers can depend on the published packages without submodules