### PR TITLE
Fix ts-proto build: moduleResolution=node10 removed in TypeScript 7

### DIFF
--- a/ts/tsconfig.ts-proto.json
+++ b/ts/tsconfig.ts-proto.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
+    "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
     "sourceMap": true,
     "outDir": "ts-proto",


### PR DESCRIPTION
## Problem
`ts/tsconfig.ts-proto.json` used `"moduleResolution": "node10"`, which TypeScript 7 (bumped in #91) removed outright rather than just deprecating:
```
tsconfig.ts-proto.json(5,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
```
This has been failing `build-ts` on every PR since #91 merged (branch protection here has no required status checks, so it merged anyway and stayed broken on master).

## Fix
Switch to `module`/`moduleResolution`: `"node16"` (the modern CommonJS-compatible pairing — TypeScript 7 also requires `module` to match when `moduleResolution` is `Node16`, hence changing both) and drop the now-irrelevant `ignoreDeprecations` option.

Verified locally: `tsc -p tsconfig.ts-proto.json` compiles cleanly with a dummy input file (full `buf generate` wasn't runnable locally, no `buf` CLI available, but the config itself now parses and compiles without error).