### PR TITLE
feat: add agent_version field + getAgentVersion RPC

### DIFF
--- a/looker/domain/v1alpha1/metrics.proto
+++ b/looker/domain/v1alpha1/metrics.proto
@@ -106,4 +106,7 @@ message OperationalMetric {
 message AgentRef {
   string agent_username = 1;
   string transport_path = 2;
+
+  // Self-reported build version of the running agent. Empty if unknown.
+  string agent_version = 3;
 }

--- a/looker/service/v1alpha1/metrics.proto
+++ b/looker/service/v1alpha1/metrics.proto
@@ -15,6 +15,8 @@ service MetricsService {
 
   rpc listMetric (ListMetricsRequest) returns (ListMetricsResponse);
   rpc lastMetric (LastMetricRequest) returns (LastMetricResponse);
+
+  rpc getAgentVersion (GetAgentVersionRequest) returns (GetAgentVersionResponse);
 }
 
 message UpdateMetricRequest {
@@ -46,6 +48,16 @@ message LastMetricRequest {
 
 message LastMetricResponse {
   google.protobuf.Timestamp last_metric_timestamp = 1;
+}
+
+message GetAgentVersionRequest {
+  // Agent UUID (same id as the canonical Agent.id from logistics)
+  string resource_id = 1;
+}
+
+message GetAgentVersionResponse {
+  // Empty if the agent has never reported a version.
+  string version = 1;
 }
 
 message TimeSerie {


### PR DESCRIPTION
## Summary
- Adds `string agent_version` to `AgentRef` (looker/domain/v1alpha1/metrics.proto), so agents can self-report their build version on the existing periodic `updateOperationalMetric` call.
- Adds a new `MetricsService.getAgentVersion` RPC (mirroring `lastMetric`) so downstream services can read the current reported version for a given agent UUID.

## Context
Part of a cross-repo change to surface the running agent version on the `/admin/agents` page in `sdm-agoora-ui`. This is step 1 in the dependency chain: sdm-proto-api → sdm-looker + agoora-agents → sdm-alfred → sdm-agoora-ui → deployment manifests.

Downstream PRs (sdm-looker, agoora-agents, sdm-alfred) are already open against the current published version and will need their `sdm-proto-api` dependency bumped once this merges and publishes.

## Test plan
- [x] `mvn -o compile` passes locally
- [ ] CI build/publish succeeds